### PR TITLE
encoding os environ flag to bytes

### DIFF
--- a/SekaiCTF_2022-FaILProof/server_files/source.py
+++ b/SekaiCTF_2022-FaILProof/server_files/source.py
@@ -1,6 +1,6 @@
 import hashlib
 from os import urandom, environ
-FLAG = environ["FLAG"]
+FLAG = environ["FLAG"].encode()
 
 
 def gen_pubkey(secret: bytes, hasher=hashlib.sha512) -> list:

--- a/SekaiCTF_2022-FaILProof_Revenge/server_files/source.py
+++ b/SekaiCTF_2022-FaILProof_Revenge/server_files/source.py
@@ -1,6 +1,6 @@
 import hashlib
 from os import urandom, environ
-FLAG = environ["FLAG"]
+FLAG = environ["FLAG"].encode()
 
 
 def gen_pubkey(secret: bytes, hasher=hashlib.sha512) -> list:

--- a/Zh3r0_CTF_V2_2021-Twist_and_Shout/server_files/challenge.py
+++ b/Zh3r0_CTF_V2_2021-Twist_and_Shout/server_files/challenge.py
@@ -1,6 +1,6 @@
 import os
 import random
-flag = os.environ["FLAG"]
+flag = os.environ["FLAG"].encode()
 
 state_len = 624*4
 right_pad = random.randint(0,state_len-len(flag))

--- a/Zh3r0_CTF_V2_2021-import_numpy_as_MT/server_files/challenge.py
+++ b/Zh3r0_CTF_V2_2021-import_numpy_as_MT/server_files/challenge.py
@@ -2,7 +2,7 @@ import os
 from numpy import random
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
-flag = os.environ["FLAG"]
+flag = os.environ["FLAG"].encode()
 
 def rand_32():
     return int.from_bytes(os.urandom(4),'big')


### PR DESCRIPTION
Fixes for the challenges 
- failproof
- failproof revenge
- twist and shout
- import numpy as mt
As flag was expected to be bytes

For the challenges - diffecient, real mersenne and chaos: flag is printed at the end (so string flag is desired)
