### PR TITLE
Fix HITCON CTF 2023 Share release file

### DIFF
--- a/HITCONCTF-2023-Share/release_files/server.py
+++ b/HITCONCTF-2023-Share/release_files/server.py
@@ -1,11 +1,1 @@
-#!/usr/bin/env python3
-from math import gcd
-import os
-
-flag = os.environ.get(
-    "FLAG", "jctf{red_flags_and_fake_flags_form_an_equivalence_class}"
-)
-
-x = int(input("x = "))
-g = gcd(x**13 + 37, (x + 42) ** 13 + 42)
-print(flag[:g])
+../server_files/server.py


### PR DESCRIPTION
Sorry, I found that HITCON CTF 2023 Share challenge have wrong release file as it didn't use a symlink. This PR fixed it.

